### PR TITLE
Support Board filtering by sending/receiving click events

### DIFF
--- a/src/apps/board/BoardApp.js
+++ b/src/apps/board/BoardApp.js
@@ -1,5 +1,30 @@
+// config - Events : Send, Receive, None (Default)
+// If sender use custom card which publishes the model of the card that is clicked.
+// If receiver filters board to the children of the received model. 
+// Mapping of types for receiver board
+// Task -> WorkProduct
+// Story -> Feature
+// PortfolioItem -> Parent
+// TestCase -> WorkProduct
+
 (function() {
     var Ext = window.Ext4 || window.Ext;
+
+    Ext.define('MyAppCard', {
+        extend: 'Rally.ui.cardboard.Card',
+        alias: 'widget.myappcard',
+        //other stuff here
+        afterRender: function() {
+            this.callParent(arguments);
+            // this.getEl().hover(this._onCardMouseOver, Ext.emptyFn, this);
+            // this.getEl().click(this._onCardMouseOver, Ext.emptyFn, this);
+            this.getEl().on("click",this._onCardMouseOver, this);
+        },
+
+        _onCardMouseOver: function() {
+            this.fireEvent('cardhover', this, this.getRecord());
+        }
+    } );
 
     Ext.define('Rally.apps.board.BoardApp', {
         extend: 'Rally.app.App',
@@ -16,7 +41,8 @@
             'Rally.clientmetrics.ClientMetricsRecordable'
         ],
         mixins: [
-            'Rally.clientmetrics.ClientMetricsRecordable'
+            'Rally.clientmetrics.ClientMetricsRecordable',
+            'Rally.Messageable'
         ],
 
         helpId: 287,
@@ -28,11 +54,24 @@
             defaultSettings: {
                 type: 'HierarchicalRequirement',
                 groupByField: 'ScheduleState',
-                showRows: false
+                showRows: false,
+                eventType : 'None'
             }
         },
 
+        _otherBoardCardClick : function(card) {
+            console.log("OtherBoardCardClick!",card);
+            this.filterToParent = card;
+            this._addBoard();
+        },
+
         launch: function() {
+            this.filterToParent = null;
+          
+            if (this.getSetting('eventType')=="Receive") {
+                this.subscribe(this, 'cardClick', this._otherBoardCardClick, this);
+            }
+
             Rally.data.ModelFactory.getModel({
                 type: this.getSetting('type'),
                 context: this.getContext().getDataContext()
@@ -40,6 +79,7 @@
                 success: function (model) {
                     this.model = model;
                     this.add(this._getGridBoardConfig());
+                    // this.publish("launchEvent");
                 },
                 scope: this
             });
@@ -110,6 +150,8 @@
         },
 
         _getBoardConfig: function() {
+            var that = this;
+
             var boardConfig = {
                 margin: '10px 0 0 0',
                 attribute: this.getSetting('groupByField'),
@@ -127,6 +169,7 @@
                     fields: (this.getSetting('fields') &&
                         this.getSetting('fields').split(',')) || []
                 }
+
             };
             if (this.getSetting('showRows')) {
                 Ext.merge(boardConfig, {
@@ -141,11 +184,47 @@
                 boardConfig.enableCrossColumnRanking = false;
                 boardConfig.cardConfig.showRankMenuItems = false;
             }
+
+            if (this.getSetting('eventType')=="Send") {
+                Ext.merge(boardConfig, {
+                    cardConfig: {
+                        xtype: 'myappcard',
+                        listeners: {
+                            'cardhover': {
+                                 fn: function(a,b,c) {
+                                    console.log("sending click:",b);
+                                    that.publish("cardClick",b);
+                                 },   
+                                 scope: this
+                             }
+                        }
+                    }
+                } )
+            }
+
             return boardConfig;
         },
 
         getSettingsFields: function() {
-            return Rally.apps.board.Settings.getFields(this.getContext());
+
+            var eventsStore = new Ext.data.ArrayStore({
+                fields: ['event'],
+                data : [['None'],['Send'],['Receive']]
+            });  
+
+            return Rally.apps.board.Settings.getFields(this.getContext())
+            .concat([
+                {
+                    name: 'eventType',
+                    xtype: 'combo',
+                    store : eventsStore,
+                    valueField : 'event',
+                    displayField : 'event',
+                    queryMode : 'local',
+                    forceSelection : true,
+                    fieldLabel: 'Events'
+                }
+            ]);
         },
 
         _shouldDisableRanking: function() {
@@ -175,6 +254,30 @@
             if (timeboxScope && timeboxScope.isApplicable(this.model)) {
                 queries.push(timeboxScope.getQueryFilter());
             }
+            if (!_.isNull(this.filterToParent)) {
+                var field = null;
+                var boardType = this.getSetting('type').toLowerCase().split("/")[0];
+                switch(boardType) {
+                    case 'task':
+                        field = 'WorkProduct'; break;
+                    case 'hierarchicalrequirement':
+                        field = 'Feature'; break;
+                    case 'portfolioitem':
+                        field = 'Parent'; break;
+                    case 'testcase':
+                        field = 'WorkProduct'; break;
+                    case 'defect':
+                        field = 'Requirement'; break;
+                    default:
+                        field = 'Parent';
+                }
+
+                var filter = Ext.create('Rally.data.wsapi.Filter', {
+                    property: field, operator: '=', value: this.filterToParent.get("_ref")
+                });
+                queries.push(filter);
+            }
+            console.log("queries",queries);
 
             return queries;
         }


### PR DESCRIPTION
@krmorse 

Filters another custom board when a card is selected. 

To configure

- Install two copies of this app. 
- Edit the App Settings and set "Events" to "Send" on one board and "Receive" on the other. 
- Items will be filtered on the Receive board in the following ways... 

**Board Type**
**Tasks** Filtered to the **WorkProduct** of the Send board item.
**Defects** : Filtered to the **WorkProduct** of the Send board item.
**TestCases** : Filtered to the **WorkProduct** of the Send board item.
**Stories** : Filtered to the **Feature** of the Send board item.
**PortfolioItem** : Filtered to the **Parent** of the Send board item.