### PR TITLE
add setting to ignore global project scope when app is on a milestone scoped page

### DIFF
--- a/src/apps/board/BoardApp.js
+++ b/src/apps/board/BoardApp.js
@@ -28,7 +28,8 @@
             defaultSettings: {
                 type: 'HierarchicalRequirement',
                 groupByField: 'ScheduleState',
-                showRows: false
+                showRows: false,
+                searchAllProjects: false,
             }
         },
 
@@ -46,8 +47,12 @@
         },
 
         _getGridBoardConfig: function() {
-            var context = this.getContext(),
-                modelNames = [this.getSetting('type')],
+            var context = this.getContext();
+            var dataContext = context.getDataContext();
+            if (this.searchAllProjects()) {
+                dataContext.project = null;
+            }
+            var modelNames = [this.getSetting('type')],
                 blackListFields = ['Successors', 'Predecessors', 'DisplayColor'],
                 whiteListFields = ['Milestones', 'Tags'],
                 config = {
@@ -103,7 +108,8 @@
                     context: context,
                     modelNames: modelNames,
                     storeConfig: {
-                        filters: this._getFilters()
+                        filters: this._getFilters(),
+                        context: dataContext
                     },
                     listeners: {
                         load: this._onLoad,
@@ -162,7 +168,11 @@
         },
 
         getSettingsFields: function() {
-            return Rally.apps.board.Settings.getFields(this.getContext());
+            var config = {
+                context: this.getContext(),
+                showSearchAllProjects: this.isMilestoneScoped()
+            }
+            return Rally.apps.board.Settings.getFields(config);
         },
 
         _shouldDisableRanking: function() {
@@ -195,6 +205,21 @@
             }
 
             return queries;
-        }
+        },
+        
+        isMilestoneScoped: function() {
+            var result = false;
+            
+            var tbscope = this.getContext().getTimeboxScope();
+            if (tbscope && tbscope.getType() == 'milestone') {
+                result = true;
+            }
+            return result
+        },
+        
+        searchAllProjects: function() {
+            var searchAllProjects = this.getSetting('searchAllProjects');
+            return this.isMilestoneScoped() && searchAllProjects;
+        },
     });
 })();

--- a/src/apps/board/Settings.js
+++ b/src/apps/board/Settings.js
@@ -12,13 +12,21 @@
             'Rally.data.wsapi.Filter'
         ],
 
-        getFields: function (context) {
+        getFields: function (config) {
             return [
+                {
+                  id:'searchAllProjects',
+                  name:'searchAllProjects',
+                  fieldLabel: 'Scope Across Workspace',
+                  labelAlign: 'left',
+                  xtype:'rallycheckboxfield',
+                  hidden: !config.showSearchAllProjects
+                },
                 {
                     name: 'type',
                     xtype: 'rallycombobox',
                     shouldRespondToScopeChange: true,
-                    context: context,
+                    context: config.context,
                     storeConfig: {
                         model: Ext.identityFn('TypeDefinition'),
                         sorters: [
@@ -129,7 +137,7 @@
                             });
                         }
                     },
-                    initialValue: context.getWorkspace().WorkspaceConfiguration.DragDropRankingEnabled ? 'DragAndDropRank' : 'Rank'
+                    initialValue: config.context.getWorkspace().WorkspaceConfiguration.DragDropRankingEnabled ? 'DragAndDropRank' : 'Rank'
                 },
                 {
                     type: 'query'


### PR DESCRIPTION
* This PR adds a new setting to the app settings.
* This setting is only shown when the app is placed on a milestone scoped page
* The setting allows the app to ignore the current project scope and instead search all projects for artifacts *if* a milestone scope is in effect.