### PR TITLE
Add ability to map Defect State to columns along with Schedule State

### DIFF
--- a/src/apps/kanban/.gitignore
+++ b/src/apps/kanban/.gitignore
@@ -1,0 +1,2 @@
+*.sublime*
+*/*.sublime*

--- a/src/apps/kanban/ColumnSettingsField.js
+++ b/src/apps/kanban/ColumnSettingsField.js
@@ -2,7 +2,7 @@
     var Ext = window.Ext4 || window.Ext;
 
     /**
-     * Allows configuration of wip and schedule state mapping for kanban columns
+     * Allows configuration of wip, schedule state, and defect state mapping for kanban columns
      *
      *      @example
      *      Ext.create('Ext.Container', {

--- a/src/apps/kanban/ColumnSettingsField.js
+++ b/src/apps/kanban/ColumnSettingsField.js
@@ -54,7 +54,7 @@
             this.callParent(arguments);
 
             this._store = Ext.create('Ext.data.Store', {
-                fields: ['column', 'shown', 'wip', 'scheduleStateMapping', 'cardFields'],
+                fields: ['column', 'shown', 'wip', 'scheduleStateMapping', 'defectStateMapping', 'cardFields'],
                 data: []
             });
 
@@ -128,6 +128,26 @@
                         xtype: 'rallyfieldvaluecombobox',
                         model: Ext.identityFn('HierarchicalRequirement'),
                         field: 'ScheduleState',
+                        listeners: {
+                            ready: function (combo) {
+                                var noMapping = {};
+                                noMapping[combo.displayField] = '--No Mapping--';
+                                noMapping[combo.valueField] = '';
+
+                                combo.store.insert(0, [noMapping]);
+                            }
+                        }
+                    }
+                },
+                {
+                    text: 'Defect State Mapping',
+                    dataIndex: 'defectStateMapping',
+                    emptyCellText: '--No Mapping--',
+                    flex: 2,
+                    editor: {
+                        xtype: 'rallyfieldvaluecombobox',
+                        model: Ext.identityFn('Defect'),
+                        field: 'State',
                         listeners: {
                             ready: function (combo) {
                                 var noMapping = {};
@@ -233,7 +253,8 @@
                 if (record.get('shown')) {
                     columns[record.get('column')] = {
                         wip: record.get('wip'),
-                        scheduleStateMapping: record.get('scheduleStateMapping')
+                        scheduleStateMapping: record.get('scheduleStateMapping'),
+                        defectStateMapping: record.get('defectStateMapping')
                     };
                     if (this.shouldShowColumnLevelFieldPicker) {
                         var cardFields = this._getCardFields(record.get('cardFields'));
@@ -284,6 +305,7 @@
                 shown: false,
                 wip: '',
                 scheduleStateMapping: '',
+                defectStateMapping: '',
                 cardFields: this.defaultCardFields
             };
 
@@ -291,7 +313,8 @@
                 Ext.apply(column, {
                     shown: true,
                     wip: pref.wip,
-                    scheduleStateMapping: pref.scheduleStateMapping
+                    scheduleStateMapping: pref.scheduleStateMapping,
+                    defectStateMapping: pref.defectStateMapping
                 });
 
                 if (pref.cardFields) {

--- a/src/apps/kanban/KanbanApp.js
+++ b/src/apps/kanban/KanbanApp.js
@@ -41,7 +41,7 @@
                     Completed: {wip: ''},
                     Accepted: {wip: ''}
                 }),
-                cardFields: 'FormattedID,Name,Owner,Discussion,Tasks,Defects', //remove with COLUMN_LEVEL_FIELD_PICKER_ON_KANBAN_SETTINGS
+                cardFields: 'FormattedID,Name,Owner,Discussion,Tasks,Defects,Iteration,State', //remove with COLUMN_LEVEL_FIELD_PICKER_ON_KANBAN_SETTINGS
                 hideReleasedCards: false,
                 showCardAge: true,
                 cardAgeThreshold: 3,
@@ -415,6 +415,9 @@
                 var setting = columnSetting[column.getValue()];
                 if (setting && setting.scheduleStateMapping) {
                     card.getRecord().set('ScheduleState', setting.scheduleStateMapping);
+                }
+                if (setting && setting.defectStateMapping) {
+                    card.getRecord().set('State', setting.defectStateMapping);
                 }
             }
         },

--- a/src/apps/kanban/KanbanApp.js
+++ b/src/apps/kanban/KanbanApp.js
@@ -41,7 +41,7 @@
                     Completed: {wip: ''},
                     Accepted: {wip: ''}
                 }),
-                cardFields: 'FormattedID,Name,Owner,Discussion,Tasks,Defects,Iteration,State', //remove with COLUMN_LEVEL_FIELD_PICKER_ON_KANBAN_SETTINGS
+                cardFields: 'FormattedID,Name,Owner,Discussion,Tasks,Defects', //remove with COLUMN_LEVEL_FIELD_PICKER_ON_KANBAN_SETTINGS
                 hideReleasedCards: false,
                 showCardAge: true,
                 cardAgeThreshold: 3,

--- a/src/apps/kanban/KanbanApp.less
+++ b/src/apps/kanban/KanbanApp.less
@@ -30,7 +30,7 @@
 }
 
 .kanban {
-  overflow-y: auto;
+  overflow-y: hidden;
 }
 
 .print-page {
@@ -42,7 +42,6 @@
       & > table {
         position: absolute; // So that there isn't a page-break between the column headers and the actual columns
         width: calc(~"100% - 24px"); // correct alignment
-        overflow-y: auto; // Trying to get the settings to allow scrolling when something other than ScheduleState is used for Columns
       }
     }
   }

--- a/src/apps/kanban/KanbanApp.less
+++ b/src/apps/kanban/KanbanApp.less
@@ -30,7 +30,7 @@
 }
 
 .kanban {
-  overflow-y: hidden;
+  overflow-y: auto;
 }
 
 .print-page {
@@ -42,6 +42,7 @@
       & > table {
         position: absolute; // So that there isn't a page-break between the column headers and the actual columns
         width: calc(~"100% - 24px"); // correct alignment
+        overflow-y: auto; // Trying to get the settings to allow scrolling when something other than ScheduleState is used for Columns
       }
     }
   }


### PR DESCRIPTION
This update allows users of the Kanban Board app to set a column mapping for both 'ScheduleState' and Defect's 'State' when moving a card across columns - especially useful when using a field like 'KanbanState' as the source for columns instead of 'ScheduleState'.

Also added a .gitignore file so that Sublime project files aren't included.